### PR TITLE
HOS CER: Addition of extra-spec hpe3par:convert_to_base;

### DIFF
--- a/cinder/tests/unit/volume/drivers/hpe/test_hpe3par.py
+++ b/cinder/tests/unit/volume/drivers/hpe/test_hpe3par.py
@@ -329,7 +329,7 @@ class HPE3PARBaseDriver(object):
     volume_type_hos = {'name': 'hos',
                        'deleted': False,
                        'updated_at': None,
-                       'extra_specs': {'convert_to_base': False},
+                       'extra_specs': {'convert_to_base': 'False'},
                        'deleted_at': None,
                        'id': 'hos'}
 
@@ -3410,7 +3410,7 @@ class HPE3PARBaseDriver(object):
         _mock_volume_types.return_value = {
             'name': 'hos',
             'extra_specs': {
-                'convert_to_base': False,
+                'convert_to_base': 'False',
                 'volume_type': self.volume_type_hos}}
         with mock.patch.object(hpecommon.HPE3PARCommon,
                                '_create_client') as mock_create_client:
@@ -3461,7 +3461,7 @@ class HPE3PARBaseDriver(object):
         _mock_volume_types.return_value = {
             'name': 'hos',
             'extra_specs': {
-                'convert_to_base': True,
+                'convert_to_base': 'True',
                 'volume_type': self.volume_type_hos}}
         with mock.patch.object(hpecommon.HPE3PARCommon,
                                '_create_client') as mock_create_client:
@@ -3522,7 +3522,7 @@ class HPE3PARBaseDriver(object):
         _mock_volume_types.return_value = {
             'name': 'hos',
             'extra_specs': {
-                'convert_to_base': False,
+                'convert_to_base': 'False',
                 'volume_type': self.volume_type_hos}}
         with mock.patch.object(hpecommon.HPE3PARCommon,
                                '_create_client') as mock_create_client:
@@ -3578,7 +3578,7 @@ class HPE3PARBaseDriver(object):
         _mock_volume_types.return_value = {
             'name': 'hos',
             'extra_specs': {
-                'convert_to_base': True,
+                'convert_to_base': 'True',
                 'volume_type': self.volume_type_hos}}
         with mock.patch.object(hpecommon.HPE3PARCommon,
                                '_create_client') as mock_create_client:

--- a/cinder/volume/drivers/hpe/hpe_3par_common.py
+++ b/cinder/volume/drivers/hpe/hpe_3par_common.py
@@ -1898,7 +1898,7 @@ class HPE3PARCommon(object):
             snap_cpg = cpg
 
         # by default, follow HOS8 behaviour i.e convert_to_base is True
-        convert_to_base = self._get_key_value(hpe3par_keys, 'convert_to_base', True)
+        convert_to_base = self._get_key_value(hpe3par_keys, 'convert_to_base', 'True')
 
         # if provisioning is not set use thin
         default_prov = self.valid_prov_values[0]
@@ -2419,17 +2419,14 @@ class HPE3PARCommon(object):
 
             self.client.createSnapshot(volume_name, snap_name, optional)
 
-            convert_to_base = self._get_key_value(hpe3par_keys, 'convert_to_base', True)
-            convert_to_base_str = str(convert_to_base)
-            LOG.debug("convert_to_base_str: " + convert_to_base_str)
-            if convert_to_base_str.lower() == 'true':
-                LOG.debug("default HOS8 behaviour")
+            convert_to_base = self._get_key_value(hpe3par_keys, 'convert_to_base', 'True')
+            LOG.debug("convert_to_base: " + convert_to_base)
+            if convert_to_base.lower() == 'true':
                 # Convert snapshot volume to base volume type
                 LOG.debug('Converting to base volume type: %s.',
                           volume['id'])
                 model_update = self._convert_to_base_volume(volume)
             else:
-                LOG.debug("HOS5 behaviour")
                 LOG.debug("volume is created as child of snapshot")
 
             # Grow the snapshot if needed
@@ -2437,7 +2434,7 @@ class HPE3PARCommon(object):
             if growth_size > 0:
                 try:
                     LOG.debug("Size of volume is greater than snapshot")
-                    if convert_to_base_str.lower() == 'false':
+                    if convert_to_base.lower() == 'false':
                         # Convert snapshot volume to base volume type
                         LOG.debug('Converting to base volume type: %s.',
                                   volume['id'])

--- a/cinder/volume/drivers/hpe/hpe_3par_common.py
+++ b/cinder/volume/drivers/hpe/hpe_3par_common.py
@@ -324,7 +324,8 @@ class HPE3PARCommon(object):
                     'priority']
     qos_priority_level = {'low': 1, 'normal': 2, 'high': 3}
     hpe3par_valid_keys = ['cpg', 'snap_cpg', 'provisioning', 'persona', 'vvs',
-                          'flash_cache', 'compression']
+                          'flash_cache', 'compression',
+                          'convert_to_base']
 
     def __init__(self, config, active_backend_id=None):
         self.config = config
@@ -1896,6 +1897,9 @@ class HPE3PARCommon(object):
         if not snap_cpg:
             snap_cpg = cpg
 
+        # by default, follow HOS8 behaviour i.e convert_to_base is True
+        convert_to_base = self._get_key_value(hpe3par_keys, 'convert_to_base', True)
+
         # if provisioning is not set use thin
         default_prov = self.valid_prov_values[0]
         prov_value = self._get_key_value(hpe3par_keys, 'provisioning',
@@ -1929,7 +1933,8 @@ class HPE3PARCommon(object):
         return {'hpe3par_keys': hpe3par_keys,
                 'cpg': cpg, 'snap_cpg': snap_cpg,
                 'vvs_name': vvs_name, 'qos': qos,
-                'tpvv': tpvv, 'tdvv': tdvv, 'volume_type': volume_type}
+                'tpvv': tpvv, 'tdvv': tdvv, 'volume_type': volume_type,
+                'convert_to_base': convert_to_base}
 
     def get_volume_settings_from_type(self, volume, host=None):
         """Get 3PAR volume settings given a volume.
@@ -1989,6 +1994,7 @@ class HPE3PARCommon(object):
                 type_info['hpe3par_keys'])
             compression = self.get_compression_policy(
                 type_info['hpe3par_keys'])
+            convert_to_base = type_info['convert_to_base']
 
             consis_group_snap_type = False
             if volume_type is not None:
@@ -2413,15 +2419,30 @@ class HPE3PARCommon(object):
 
             self.client.createSnapshot(volume_name, snap_name, optional)
 
-            # Convert snapshot volume to base volume type
-            LOG.debug('Converting to base volume type: %s.',
-                      volume['id'])
-            model_update = self._convert_to_base_volume(volume)
+            convert_to_base = self._get_key_value(hpe3par_keys, 'convert_to_base', True)
+            convert_to_base_str = str(convert_to_base)
+            LOG.debug("convert_to_base_str: " + convert_to_base_str)
+            if convert_to_base_str.lower() == 'true':
+                LOG.debug("default HOS8 behaviour")
+                # Convert snapshot volume to base volume type
+                LOG.debug('Converting to base volume type: %s.',
+                          volume['id'])
+                model_update = self._convert_to_base_volume(volume)
+            else:
+                LOG.debug("HOS5 behaviour")
+                LOG.debug("volume is created as child of snapshot")
 
             # Grow the snapshot if needed
             growth_size = volume['size'] - snapshot['volume_size']
             if growth_size > 0:
                 try:
+                    LOG.debug("Size of volume is greater than snapshot")
+                    if convert_to_base_str.lower() == 'false':
+                        # Convert snapshot volume to base volume type
+                        LOG.debug('Converting to base volume type: %s.',
+                                  volume['id'])
+                        model_update = self._convert_to_base_volume(volume)
+
                     growth_size_mib = growth_size * units.Gi / units.Mi
                     LOG.debug('Growing volume: %(id)s by %(size)s GiB.',
                               {'id': volume['id'], 'size': growth_size})

--- a/create_volume_from_snapshot.md
+++ b/create_volume_from_snapshot.md
@@ -1,44 +1,49 @@
+
 ## Creation of volume from snapshot
 ---
 
 #### Need for this enhancement:
 In HOS8, while creating volume from a snapshot, volume is created independently i.e it is decoupled from snapshot.
 
-V1
-|
-&nbsp;\`S1
-&nbsp;&nbsp;|
+V1<br/>
++<br/>
+|<br/>
++--- S1<br/>
+|<br/>
++<br/>
 V2
+
 
 While creating large number of instances (bootable volumes) from snapshots, timeouts are observed.
 This is because volume cannot be resized until background copying task is finished.
 
 #### Solution:
-A new extra spec has been added on the volume.
-Name - **hpe3par:convert_to_base**;
-Value - True/False; defaults to True
-True: Volume (from snapshot) is created independently i.e HOS8 behavior
-False: Volume (from snapshot) is created as child of snapshot i.e HOS5 behavior
+A new extra spec has been added on the volume.<br/>
+Name - **hpe3par:convert_to_base**<br/>
+Value - True/False; defaults to True<br/>
+- True: Volume (from snapshot) is created independently i.e HOS8 behavior
+- False: Volume (from snapshot) is created as child of snapshot i.e HOS5 behavior
 
 In below examples, volume-type named "silver" is used.
 
-**Set the extra-spec**:
+**Set the extra-spec**:<br/>
 `cinder type-key silver set hpe3par:convert_to_base=False`
 
-**Verify**:
+**Verify**:<br/>
 `cinder extra-specs-list`
 
-**Remove the extra-spec**:
+**Remove the extra-spec**:<br/>
 `cinder type-key silver unset hpe3par:convert_to_base`
 
-**Volume creation example**:
-`cinder create --name v1 --volume-type silver 5`
-`cinder snapshot-create --name s1 v1`
-`cinder snapshot-list`
-`cinder create --snapshot-id <snap_id> --volume-type silver --name v2 5`
+**Volume creation example**:<br/>
+`cinder create --name v1 --volume-type silver 5`<br/>
+`cinder snapshot-create --name s1 v1`<br>
+`cinder snapshot-list`<br/>
+`cinder create --snapshot-id <snap_id> --volume-type silver --name v2 5`<br/>
 
 #### Note regarding size of V2:
 If size of V1 and V2 is same, then the proposed solution works perfectly.
 
 However, if size of V2 is greater than size of V1, then volume cannot be grown.
 In this case, to avoid any error, V2 is converted to base volume i.e HOS 8 behavior.
+

--- a/create_volume_from_snapshot.md
+++ b/create_volume_from_snapshot.md
@@ -1,0 +1,44 @@
+## Creation of volume from snapshot
+---
+
+#### Need for this enhancement:
+In HOS8, while creating volume from a snapshot, volume is created independently i.e it is decoupled from snapshot.
+
+V1
+|
+&nbsp;\`S1
+&nbsp;&nbsp;|
+V2
+
+While creating large number of instances (bootable volumes) from snapshots, timeouts are observed.
+This is because volume cannot be resized until background copying task is finished.
+
+#### Solution:
+A new extra spec has been added on the volume.
+Name - **hpe3par:convert_to_base**;
+Value - True/False; defaults to True
+True: Volume (from snapshot) is created independently i.e HOS8 behavior
+False: Volume (from snapshot) is created as child of snapshot i.e HOS5 behavior
+
+In below examples, volume-type named "silver" is used.
+
+**Set the extra-spec**:
+`cinder type-key silver set hpe3par:convert_to_base=False`
+
+**Verify**:
+`cinder extra-specs-list`
+
+**Remove the extra-spec**:
+`cinder type-key silver unset hpe3par:convert_to_base`
+
+**Volume creation example**:
+`cinder create --name v1 --volume-type silver 5`
+`cinder snapshot-create --name s1 v1`
+`cinder snapshot-list`
+`cinder create --snapshot-id <snap_id> --volume-type silver --name v2 5`
+
+#### Note regarding size of V2:
+If size of V1 and V2 is same, then the proposed solution works perfectly.
+
+However, if size of V2 is greater than size of V1, then volume cannot be grown.
+In this case, to avoid any error, V2 is converted to base volume i.e HOS 8 behavior.


### PR DESCRIPTION
HPE 3PAR Cinder Driver we are introducting a new extra spec called `hpe3par:convert_to_base=False|True`   default value of this extra spec is `True`

Behaviour of the volume creation from --snapshot-id when this setting is set to
- True: Volume (from snapshot) is created independently i.e HOS8 behavior
- False: Volume (from snapshot) is created as child of snapshot i.e HOS5 behavior

Readme for this change:
https://github.com/hpe-storage/Cinder-Pike/blob/master/create_volume_from_snapshot.md